### PR TITLE
feat(docs): more links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TypeID
 
-TypeIDs are a draft standard for *type-safe, globally unique identifiers* based on the upcoming [UUIDv7 standard]. Their properties, particularly k-sortability, make them suitable primary identifiers for classic database systems like PostgreSQL. However, k-sortability may not always be desirable. For instance, you might require an identifier with high randomness entropy for security reasons. Additionally, in distributed database systems like CockroachDB, having a k-sortable primary key can lead to hotspots and performance issues.
+TypeIDs are a draft standard for *type-safe, globally unique identifiers* based on the upcoming [UUIDv7 standard](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-versions). Their properties, particularly k-sortability, make them suitable primary identifiers for classic database systems like PostgreSQL. However, k-sortability may not always be desirable. For instance, you might require an identifier with high randomness entropy for security reasons. Additionally, in distributed database systems like CockroachDB, having a k-sortable primary key can lead to hotspots and performance issues.
 
-While this package draws inspiration from the original typeid Go package ([github.com/jetify-com/typeid-go]), it provides multiple ID types:
+While this package draws inspiration from the original typeid Go package ([github.com/jetify-com/typeid-go](https://github.com/jetify-com/typeid-go)), it provides multiple ID types:
 
-- [`typeid.Sortable`] is based on UUIDv7 and is k-sortable. Its implementation adheres to the draft standard. The suffix part is encoded in **lowercase** crockford base32.
-- [`typeid.Random`] is also based on UUIDv4 and is completely random. Unlike `typeid.Sortable`, the suffix part is encoded in **uppercase** crockford base32.
+- `typeid.Sortable` is based on UUIDv7[^UUIDv7] and is k-sortable. Its implementation adheres to the draft standard. The suffix part is encoded in **lowercase** crockford base32.
+- `typeid.Random` is also based on UUIDv4[^UUIDv4] and is completely random. Unlike `typeid.Sortable`, the suffix part is encoded in **uppercase** crockford base32.
 
 Please refer to the respective type documentation for more details.
 
@@ -17,7 +17,7 @@ go install github.com/sumup/typeid
 
 # Usage
 
-To create a new ID type, define a prefix type that implements the [Prefix] interface. Then, define a TypeAlias for your ID type to [Random] or [Sortable] with your prefix type as generic argument.
+To create a new ID type, define a prefix type that implements the `typeid.Prefix` interface. Then, define a TypeAlias for your ID type to `typeid.Random` or `typeid.Sortable` with your prefix type as generic argument.
 
 Example:
 
@@ -36,17 +36,15 @@ userID, err := typeid.New[UserID]()
 if err != nil {
     fmt.Println("create user id:", err)
 }
+
 fmt.Println(userID) // --> user_01hf98sp99fs2b4qf2jm11hse4
 ```
 
 # Database Support
 
-ID types in this package can be used with [database/sql] and [github.com/jackc/pgx].
+ID types in this package can be used with [database/sql](https://pkg.go.dev/database/sql) and [github.com/jackc/pgx](https://pkg.go.dev/github.com/jackc/pgx/v5).
 
 When using the standard library sql, IDs will be stored as their string representation and can be scanned and valued accordingly. When using pgx, both TEXT and UUID columns can be used directly. However, note that the type information is lost when using UUID columns, unless you take additional steps at the database layer. Be mindful of your identifier semantics, especially in complex JOIN queries.
-
-[UUIDv7 standard]: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-versions
-[UUIDv4 standard]: https://datatracker.ietf.org/doc/html/rfc4122
 
 ### Maintainers
 
@@ -57,3 +55,6 @@ When using the standard library sql, IDs will be stored as their string represen
 
 Based on the go implementation of typeid found at: https://github.com/jetify-com/typeid-go by [Jetify](https://www.jetify.com/).
 Modifications made available under the same license as the original.
+
+[^UUIDv7]: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-versions
+[^UUIDv4]: https://datatracker.ietf.org/doc/html/rfc4122

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeID
 
-TypeIDs are a draft standard for *type-safe, globally unique identifiers* based on the upcoming [UUIDv7 standard](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-versions). Their properties, particularly k-sortability, make them suitable primary identifiers for classic database systems like PostgreSQL. However, k-sortability may not always be desirable. For instance, you might require an identifier with high randomness entropy for security reasons. Additionally, in distributed database systems like CockroachDB, having a k-sortable primary key can lead to hotspots and performance issues.
+TypeIDs are a draft standard for *type-safe, globally unique identifiers* based on the [UUIDv7 standard](https://datatracker.ietf.org/doc/html/rfc9562). Their properties, particularly k-sortability, make them suitable primary identifiers for classic database systems like PostgreSQL. However, k-sortability may not always be desirable. For instance, you might require an identifier with high randomness entropy for security reasons. Additionally, in distributed database systems like CockroachDB, having a k-sortable primary key can lead to hotspots and performance issues.
 
 While this package draws inspiration from the original typeid Go package ([github.com/jetify-com/typeid-go](https://github.com/jetify-com/typeid-go)), it provides multiple ID types:
 
@@ -56,5 +56,5 @@ When using the standard library sql, IDs will be stored as their string represen
 Based on the go implementation of typeid found at: https://github.com/jetify-com/typeid-go by [Jetify](https://www.jetify.com/).
 Modifications made available under the same license as the original.
 
-[^UUIDv7]: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-versions
+[^UUIDv7]: https://datatracker.ietf.org/doc/html/rfc9562
 [^UUIDv4]: https://datatracker.ietf.org/doc/html/rfc4122


### PR DESCRIPTION
UUIDv7 was published yesterday: https://datatracker.ietf.org/doc/html/rfc9562 so no longer "upcoming".

Also fix a bunch of missing links as we started from a README that was generated from Go docs.