### PR TITLE
chore: Bump Go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        version: ["1.21", "1.22", "1.23"]
+        version: ["1.22", "1.23", "1.24"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sumup/typeid
 
-go 1.21
+go 1.22
 
 require (
 	github.com/gofrs/uuid/v5 v5.3.1


### PR DESCRIPTION
With Go 1.24 being released and our promise to support the last 3 main versions, we should now support (and test against), 1.22, 1.23 and 1.24.