### PR TITLE
feat: support multi-word prefixes

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -1,7 +1,6 @@
 package typeid
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/gofrs/uuid/v5"
@@ -48,10 +47,6 @@ func scan[T idImplementation[P], P Prefix](dst *T, src any) error {
 	return nil
 }
 
-var (
-	errNilScan = errors.New("cannot scan NULL into *typeid.TypeID")
-)
-
 func textValue[T idImplementation[P], P Prefix](id T) (pgtype.Text, error) {
 	return pgtype.Text{
 		String: id.String(),
@@ -63,7 +58,7 @@ func scanText[T idImplementation[P], P Prefix](dst *T, v pgtype.Text) error {
 	var err error
 
 	if !v.Valid {
-		return errNilScan
+		return fmt.Errorf("cannot scan NULL into %T", dst)
 	}
 
 	*dst, err = FromString[T](v.String)
@@ -85,7 +80,7 @@ func scanUUID[T idImplementation[P], P Prefix](dst *T, v pgtype.UUID) error {
 	var err error
 
 	if !v.Valid {
-		return errNilScan
+		return fmt.Errorf("cannot scan NULL into %T", dst)
 	}
 
 	*dst, err = FromUUIDBytes[T](v.Bytes[:])

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -205,7 +205,7 @@ func TestTypeID_SQL_Value(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	str := "account_00041061050r3gg28a1c60t3gf"
+	str := "system_account_00041061050r3gg28a1c60t3gf"
 	tid := Must(FromString[AccountID](str))
 
 	encoded, err := json.Marshal(tid)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -78,8 +78,9 @@ func TestTypeID_Pgx_Scan(t *testing.T) {
 		if err == nil {
 			t.Error("must error on a nil scan")
 		}
-		if !strings.Contains(err.Error(), "cannot scan NULL into *typeid.TypeID") {
-			t.Error("error must be cannot scan NULL into *typeid.TypeID")
+		expect := "cannot scan NULL into *typeid.Random[github.com/sumup/typeid.userPrefix]"
+		if !strings.Contains(err.Error(), expect) {
+			t.Errorf("error must be %q, was %q", expect, err.Error())
 		}
 	})
 }

--- a/generate.go
+++ b/generate.go
@@ -2,7 +2,6 @@ package typeid
 
 import (
 	"fmt"
-	"regexp"
 	"unsafe"
 
 	"github.com/gofrs/uuid/v5"
@@ -58,10 +57,6 @@ func nilID[P Prefix]() typedID[P] {
 	}
 }
 
-var (
-	prefixRegexp = regexp.MustCompile("^[a-z](?:[a-z_]*[a-z])?$")
-)
-
 func validatePrefix(prefix string) error {
 	if prefix == "" {
 		return nil
@@ -71,9 +66,11 @@ func validatePrefix(prefix string) error {
 		return fmt.Errorf("invalid prefix: %s, prefix length is %d, expected <= %d", prefix, len(prefix), MaxPrefixLen)
 	}
 
-	// Ensure that the prefix has only lowercase ASCII characters
-	if !prefixRegexp.MatchString(prefix) {
-		return fmt.Errorf("invalid prefix: '%s', prefix must match %q", prefix, prefixRegexp.String())
+	// Ensure that the prefix has only lowercase ASCII characters and underscores
+	for _, c := range prefix {
+		if c != '_' && (c < 'a' || c > 'z') {
+			return fmt.Errorf("invalid prefix: '%s', prefix should match [a-z_]{0,%d}", prefix, MaxPrefixLen)
+		}
 	}
 
 	return nil

--- a/generate.go
+++ b/generate.go
@@ -2,6 +2,7 @@ package typeid
 
 import (
 	"fmt"
+	"regexp"
 	"unsafe"
 
 	"github.com/gofrs/uuid/v5"
@@ -57,21 +58,24 @@ func nilID[P Prefix]() typedID[P] {
 	}
 }
 
+var (
+	prefixRegexp = regexp.MustCompile("^[a-z](?:[a-z_]*[a-z])?$")
+)
+
 func validatePrefix(prefix string) error {
 	if prefix == "" {
 		return nil
 	}
 
 	if len(prefix) > MaxPrefixLen {
-		return fmt.Errorf("invalid prefix: %s. Prefix length is %d, expected <= %d", prefix, len(prefix), MaxPrefixLen)
+		return fmt.Errorf("invalid prefix: %s, prefix length is %d, expected <= %d", prefix, len(prefix), MaxPrefixLen)
 	}
 
 	// Ensure that the prefix has only lowercase ASCII characters
-	for _, c := range prefix {
-		if c < 'a' || c > 'z' {
-			return fmt.Errorf("invalid prefix: '%s'. Prefix should match [a-z]{0,%d}", prefix, MaxPrefixLen)
-		}
+	if !prefixRegexp.MatchString(prefix) {
+		return fmt.Errorf("invalid prefix: '%s', prefix must match %q", prefix, prefixRegexp.String())
 	}
+
 	return nil
 }
 

--- a/typeid.go
+++ b/typeid.go
@@ -80,15 +80,16 @@ func MustNew[T instance[P], P Prefix]() T {
 }
 
 func FromString[T instance[P], P Prefix](s string) (T, error) {
-	prefix := getPrefix[P]() + "_"
-	if !strings.HasPrefix(s, prefix) {
-		return Nil[T](), fmt.Errorf("invalid prefix for typeid %T, expected %s", T{}, getPrefix[P]())
+	prefix := getPrefix[P]()
+	if prefix != "" && !strings.HasPrefix(s, prefix+"_") {
+		return Nil[T](), fmt.Errorf("invalid prefix for typeid %T, expected %q", T{}, prefix)
 	}
 
-	suffix := strings.TrimPrefix(s, prefix)
+	suffix := strings.TrimPrefix(s, prefix+"_")
+
 	tid, err := from[P](suffix, T{}.processor())
 	if err != nil {
-		return Nil[T](), fmt.Errorf("parse typeid suffix `%s`: %w", suffix, err)
+		return Nil[T](), fmt.Errorf("parse typeid suffix %q: %w", suffix, err)
 	}
 	return T{tid}, nil
 }

--- a/typeid.go
+++ b/typeid.go
@@ -1,10 +1,15 @@
 package typeid
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/gofrs/uuid/v5"
+)
+
+var (
+	ErrParse = errors.New("parse typeid")
 )
 
 const (
@@ -82,14 +87,14 @@ func MustNew[T instance[P], P Prefix]() T {
 func FromString[T instance[P], P Prefix](s string) (T, error) {
 	prefix := getPrefix[P]()
 	if prefix != "" && !strings.HasPrefix(s, prefix+"_") {
-		return Nil[T](), fmt.Errorf("invalid prefix for typeid %T, expected %q", T{}, prefix)
+		return Nil[T](), fmt.Errorf("%w: invalid prefix for %T, expected %q", ErrParse, T{}, prefix)
 	}
 
 	suffix := strings.TrimPrefix(s, prefix+"_")
 
 	tid, err := from[P](suffix, T{}.processor())
 	if err != nil {
-		return Nil[T](), fmt.Errorf("parse typeid suffix %q: %w", suffix, err)
+		return Nil[T](), fmt.Errorf("%w: invalid suffix %q: %s", ErrParse, suffix, err.Error())
 	}
 	return T{tid}, nil
 }
@@ -105,7 +110,7 @@ func FromUUID[T instance[P], P Prefix](u uuid.UUID) (T, error) {
 func FromUUIDStr[T instance[P], P Prefix](uuidStr string) (T, error) {
 	u, err := uuid.FromString(uuidStr)
 	if err != nil {
-		return Nil[T](), fmt.Errorf("typeid from uuid string: %w", err)
+		return Nil[T](), fmt.Errorf("%w: uuid from string: %s", ErrParse, err.Error())
 	}
 	return FromUUID[T](u)
 }
@@ -113,7 +118,7 @@ func FromUUIDStr[T instance[P], P Prefix](uuidStr string) (T, error) {
 func FromUUIDBytes[T instance[P], P Prefix](bytes []byte) (T, error) {
 	u, err := uuid.FromBytes(bytes)
 	if err != nil {
-		return Nil[T](), fmt.Errorf("typeid from uuid: %w", err)
+		return Nil[T](), fmt.Errorf("%w: uuid from bytes: %s", ErrParse, err.Error())
 	}
 	return FromUUID[T](u)
 }

--- a/typeid_test.go
+++ b/typeid_test.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	userIDPrefix    = "user"
-	accountIDPrefix = "account"
+	accountIDPrefix = "system_account"
 
 	emptyID = "00000000000000000000000000" // empty is suffix is 26 zeros
 )
@@ -70,7 +70,7 @@ func TestTypeID_Nil(t *testing.T) {
 	}
 
 	nilAccountID := Nil[AccountID]()
-	if "account_"+emptyID != nilAccountID.String() {
+	if "system_account_"+emptyID != nilAccountID.String() {
 		t.Errorf("expected nil account id, got: %s", nilAccountID.String())
 	}
 

--- a/typeid_test.go
+++ b/typeid_test.go
@@ -88,6 +88,9 @@ func TestTypeID_ToFrom(t *testing.T) {
 
 	type SortableID = AccountID
 	t.Run("typeid.Sortable", runToFromQuickTests[SortableID])
+
+	type EmptyPrefixID = NilID
+	t.Run("empty prefix", runToFromQuickTests[EmptyPrefixID])
 }
 
 func runToFromQuickTests[T idImplementation[P], P Prefix](t *testing.T) {


### PR DESCRIPTION
Allow prefixes to contain multiple words separated by underscores (`_`). Currently, prefix can only contain `a-z`, this commit allows prefix to be any string that's shorter than 63 character (existing limit) but allow the prefix to contain non-successive underscores (underscore at the beginning or the end of the prefix is not allowed).